### PR TITLE
一部センサ値取得関数などをリファクタ

### DIFF
--- a/controllers/main_sim/Controller.cpp
+++ b/controllers/main_sim/Controller.cpp
@@ -1,5 +1,6 @@
 #include "includes/Controller.hpp"
 #include "drivers/includes/ColorSensor.hpp"
+#include "drivers/includes/LineSensor.hpp"
 #include "drivers/includes/Position.hpp"
 #include "includes/CommonDefine.hpp"
 #include <webots/Supervisor.hpp>
@@ -71,6 +72,6 @@ ColorSensor::ColorValue Controller::getColorValue() {
     return this->colorSensor->getColorValue();
 }
 
-void Controller::getLineValue(int* left, int* center, int* right) {
-    this->lineSensor->getLineValue(left, center, right);
+LineSensor::LineValue Controller::getLineValue() {
+    return this->lineSensor->getLineValue();
 }

--- a/controllers/main_sim/Controller.cpp
+++ b/controllers/main_sim/Controller.cpp
@@ -1,5 +1,6 @@
 #include "includes/Controller.hpp"
 #include "drivers/includes/ColorSensor.hpp"
+#include "drivers/includes/Position.hpp"
 #include "includes/CommonDefine.hpp"
 #include <webots/Supervisor.hpp>
 
@@ -42,8 +43,8 @@ void Controller::positionReset(void) {
     position->reset();
 }
 
-void Controller::getPosition(float* distance, float* angle) {
-    position->getPosition(distance, angle);
+Position::PositionValue Controller::getPosition() {
+    return position->getPosition();
 }
 
 void Controller::changeDriveMode(Mode mode, int motorPower) {

--- a/controllers/main_sim/Controller.cpp
+++ b/controllers/main_sim/Controller.cpp
@@ -46,8 +46,8 @@ void Controller::getPosition(float* distance, float* angle) {
     position->getPosition(distance, angle);
 }
 
-void Controller::changeDriveMode(Mode mode, int pwmDuty) {
-    this->twinWheelDriver->changeDriveMode(mode, pwmDuty);
+void Controller::changeDriveMode(Mode mode, int motorPower) {
+    this->twinWheelDriver->changeDriveMode(mode, motorPower);
 }
 
 bool Controller::clockForward() {

--- a/controllers/main_sim/Event.cpp
+++ b/controllers/main_sim/Event.cpp
@@ -1,6 +1,7 @@
 #include "includes/Event.hpp"
 #include "includes/Controller.hpp"
 #include "drivers/includes/ColorSensor.hpp"
+#include "drivers/includes/LineSensor.hpp"
 #include "drivers/includes/Position.hpp"
 #include "iostream"
 #include "includes/CommonDefine.hpp"
@@ -20,9 +21,7 @@ Event::Event(Controller *controller) {
     this->distanceOld = 0.0F;
     this->angleOld = 0.0F;
     this->colorOld = (ColorSensor::ColorValue){0,0,0};
-    this->lineLeftOld = 0;
-    this->lineCenterOld = 0;
-    this->lineRightOld = 0;
+    this->lineValueOld = (LineSensor::LineValue){0,0,0};
 }
 
 int Event::updateEvent() {
@@ -36,17 +35,15 @@ int Event::updateEvent() {
     ColorSensor::ColorValue color;
     Position::PositionValue position;
 
-    int lineLeft;
-    int lineCenter;
-    int lineRight;
-
+    LineSensor::LineValue lineValue;
+    
     rangeDistance = controller->getRange();
     color = controller->getColorValue();
-    controller->getLineValue(&lineLeft, &lineCenter, &lineRight);
+    lineValue = controller->getLineValue();
     bool lineSensorChanged =
-        (lineLeft != this->lineLeftOld) ||
-        (lineCenter != this->lineCenterOld) ||
-        (lineRight != this->lineRightOld);
+        (lineValue.left != this->lineValueOld.left) ||
+        (lineValue.center != this->lineValueOld.center) ||
+        (lineValue.right != this->lineValueOld.right);
 
     if(key == 'Q'){
         return -1;
@@ -123,17 +120,14 @@ int Event::updateEvent() {
     this->angleOld = position.angle;
     this->rangeDistanceOld = rangeDistance;
     this->colorOld = color;
-    this->lineLeftOld = lineLeft;
-    this->lineCenterOld = lineCenter;
-    this->lineRightOld = lineRight;
-
+    this->lineValueOld = lineValue;
     std::cout << "distance=" << position.distance << " "
               << "angle=" << position.angle << " " << std::endl;
     std::cout << "range=" << rangeDistance << std::endl;
     std::cout << "color: R=" << color.red << " G=" << color.green << " B=" << color.blue << std::endl;
-    std::cout << "line:l=" << lineLeft << " "
-              << "line:c=" << lineCenter << " "
-              << "line:r=" << lineRight << " " << std::endl;
+    std::cout << "line:l=" << lineValue.left << " "
+              << "line:c=" << lineValue.center << " "
+              << "line:r=" << lineValue.right << " " << std::endl;
     return 0;
 }
 

--- a/controllers/main_sim/Event.cpp
+++ b/controllers/main_sim/Event.cpp
@@ -18,8 +18,7 @@ Event::Event(Controller *controller) {
     this->oldKey = -1;
     this->rangeDistanceOld = 0.0F;
     keyboard.enable(100);
-    this->distanceOld = 0.0F;
-    this->angleOld = 0.0F;
+    this->positionOld = (Position::PositionValue){0.0F, 0.0F};
     this->colorOld = (ColorSensor::ColorValue){0,0,0};
     this->lineValueOld = (LineSensor::LineValue){0,0,0};
 }
@@ -50,8 +49,8 @@ int Event::updateEvent() {
     }
 
     position = controller->getPosition();
-    absDistanceDiff = ABS_FLOAT(this->distanceOld - position.distance);
-    absAngleDiff = ABS_FLOAT(this->angleOld - position.angle);
+    absDistanceDiff = ABS_FLOAT(this->positionOld.distance - position.distance);
+    absAngleDiff = ABS_FLOAT(this->positionOld.angle - position.angle);
 
     // TODO 測距センサの誤差で実質ここ常に発火してしまう
     if(rangeDistance != this->rangeDistanceOld){
@@ -116,8 +115,7 @@ int Event::updateEvent() {
         this->event &= ~E_CHANGE_ANGLE;
     }
 
-    this->distanceOld = position.distance;
-    this->angleOld = position.angle;
+    this->positionOld = position;
     this->rangeDistanceOld = rangeDistance;
     this->colorOld = color;
     this->lineValueOld = lineValue;

--- a/controllers/main_sim/Event.cpp
+++ b/controllers/main_sim/Event.cpp
@@ -1,6 +1,7 @@
 #include "includes/Event.hpp"
 #include "includes/Controller.hpp"
 #include "drivers/includes/ColorSensor.hpp"
+#include "drivers/includes/Position.hpp"
 #include "iostream"
 #include "includes/CommonDefine.hpp"
 #include <fcntl.h>
@@ -26,8 +27,6 @@ Event::Event(Controller *controller) {
 
 int Event::updateEvent() {
     int key = keyboard.getKey();
-    float distance;
-    float angle;
 
     float absDistanceDiff;
     float absAngleDiff;
@@ -35,6 +34,7 @@ int Event::updateEvent() {
     float rangeDistance;
 
     ColorSensor::ColorValue color;
+    Position::PositionValue position;
 
     int lineLeft;
     int lineCenter;
@@ -52,9 +52,9 @@ int Event::updateEvent() {
         return -1;
     }
 
-    controller->getPosition(&distance, &angle);
-    absDistanceDiff = ABS_FLOAT(this->distanceOld - distance);
-    absAngleDiff = ABS_FLOAT(this->angleOld - angle);
+    position = controller->getPosition();
+    absDistanceDiff = ABS_FLOAT(this->distanceOld - position.distance);
+    absAngleDiff = ABS_FLOAT(this->angleOld - position.angle);
 
     // TODO 測距センサの誤差で実質ここ常に発火してしまう
     if(rangeDistance != this->rangeDistanceOld){
@@ -119,16 +119,16 @@ int Event::updateEvent() {
         this->event &= ~E_CHANGE_ANGLE;
     }
 
-    this->distanceOld = distance;
-    this->angleOld = angle;
+    this->distanceOld = position.distance;
+    this->angleOld = position.angle;
     this->rangeDistanceOld = rangeDistance;
     this->colorOld = color;
     this->lineLeftOld = lineLeft;
     this->lineCenterOld = lineCenter;
     this->lineRightOld = lineRight;
 
-    std::cout << "distance=" << distance << " "
-              << "angle=" << angle << " " << std::endl;
+    std::cout << "distance=" << position.distance << " "
+              << "angle=" << position.angle << " " << std::endl;
     std::cout << "range=" << rangeDistance << std::endl;
     std::cout << "color: R=" << color.red << " G=" << color.green << " B=" << color.blue << std::endl;
     std::cout << "line:l=" << lineLeft << " "

--- a/controllers/main_sim/LEDTank.cpp
+++ b/controllers/main_sim/LEDTank.cpp
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include "drivers/includes/Position.hpp"
 #include "includes/Event.hpp"
 #include "includes/LEDTank.hpp"
 #include "includes/CommonDefine.hpp"
@@ -8,8 +9,7 @@
 LEDTank::LEDTank(Controller *controller){
   this->state = _STATE_INITIAL;
   this->controller = controller;
-  this->distance = 0.0F;
-  this->angle = 0.0F;
+  this->position = (Position::PositionValue){0.0F, 0.0F};
   this->rangeDistance = 0.0F;
 }
 
@@ -18,7 +18,7 @@ LEDTank::LEDTank(Controller *controller){
  * 実験用
  */
 void LEDTank::execState(){
-  controller->getPosition(&distance, &angle);
+  position = controller->getPosition();
   switch(this->_state){
   case STATE_FORWARD:
     break;

--- a/controllers/main_sim/drivers/LineSensor.cpp
+++ b/controllers/main_sim/drivers/LineSensor.cpp
@@ -41,20 +41,22 @@ LineSensor* LineSensor::getInstance(
     return _instance;
 }
 
-void LineSensor::getLineValue(int* left, int* center, int* right){
+LineSensor::LineValue LineSensor::getLineValue(){
+    LineSensor::LineValue lineValue;
     if(this->sensorElementLeft->getValue() > THRESHOLD_LINE_VALUE) {
-        *left = LINE_SENSOR_VALUE_BLACK;
+        lineValue.left = LINE_SENSOR_VALUE_BLACK;
     } else {
-        *left = LINE_SENSOR_VALUE_WHITE;
+        lineValue.left = LINE_SENSOR_VALUE_WHITE;
     }
     if(this->sensorElementCenter->getValue() > THRESHOLD_LINE_VALUE) {
-        *center = LINE_SENSOR_VALUE_BLACK;
+        lineValue.center = LINE_SENSOR_VALUE_BLACK;
     } else {
-        *center = LINE_SENSOR_VALUE_WHITE;
+        lineValue.center = LINE_SENSOR_VALUE_WHITE;
     }
     if(this->sensorElementRight->getValue() > THRESHOLD_LINE_VALUE) {
-        *right = LINE_SENSOR_VALUE_BLACK;
+        lineValue.right = LINE_SENSOR_VALUE_BLACK;
     } else {
-        *right = LINE_SENSOR_VALUE_WHITE;
+        lineValue.right = LINE_SENSOR_VALUE_WHITE;
     }
+    return lineValue;
 }

--- a/controllers/main_sim/drivers/Position.cpp
+++ b/controllers/main_sim/drivers/Position.cpp
@@ -32,19 +32,19 @@ void Position::reset(void) {
     referPositionR  = positionSensorR->getValue();
 }
 
-void Position::getPosition(float* distance, float* angle) {
+Position::PositionValue Position::getPosition() {
     float l;
     float r;
     float radNowL;
     float radNowR;
-    float distanceTemp;
 
     radNowL = positionSensorL->getValue();
     radNowR = positionSensorR->getValue();
     l = (radNowL - referPositionL) * RADIUS;
     r = (radNowR - referPositionR) * RADIUS;
 
-    distanceTemp = (l + r) / 2.0;
-    *angle = (( l - r ) / TREAD) * 180.0 / PI;
-    *distance = distanceTemp;
+    return (Position::PositionValue){
+        (float)((l + r) / 2.0), //distance
+        (float)((( l - r ) / TREAD) * 180.0 / PI) //angle
+    };
 }

--- a/controllers/main_sim/drivers/TwinWheelDriver.cpp
+++ b/controllers/main_sim/drivers/TwinWheelDriver.cpp
@@ -21,10 +21,10 @@ TwinWheelDriver::TwinWheelDriver(Supervisor* supervisor, std::string motorNameL,
   motorR->setPosition(INFINITY);
 }
 
-void TwinWheelDriver::changeDriveMode(Mode mode, int voltageLevel) {
+void TwinWheelDriver::changeDriveMode(Mode mode, int motorPower) {
     //voltage_level : 0〜100
-    double l = ((double) voltageLevel * MAX_SPEED / 100.0) * (L_MOTOR_COFF / 100) ;
-    double r = ((double) voltageLevel * MAX_SPEED / 100.0) * (R_MOTOR_COFF / 100) ;
+    double l = ((double) motorPower * MAX_SPEED / 100.0) * (L_MOTOR_COFF / 100) ;
+    double r = ((double) motorPower * MAX_SPEED / 100.0) * (R_MOTOR_COFF / 100) ;
 
     if (mode == STOP) {
         motorL->setVelocity(0.0);

--- a/controllers/main_sim/drivers/includes/LineSensor.hpp
+++ b/controllers/main_sim/drivers/includes/LineSensor.hpp
@@ -30,7 +30,8 @@ public:
         std::string sensorNameRight,
         int timeStep
     );
-    void getLineValue(int* left, int* center, int* right);
+    typedef struct{int left, center, right;} LineValue;
+    LineSensor::LineValue getLineValue();
 };
 
 #endif

--- a/controllers/main_sim/drivers/includes/Position.hpp
+++ b/controllers/main_sim/drivers/includes/Position.hpp
@@ -18,7 +18,8 @@ public:
     PositionSensor* positionSensorR;
     static Position* getInstance(Supervisor* supervisor, std::string psNameL, std::string psNameR);
     void reset(void);
-    void getPosition(float* distance, float* angle);
+    typedef struct {float distance, angle;} PositionValue;
+    Position::PositionValue getPosition();
 };
 
 #endif

--- a/controllers/main_sim/includes/Controller.hpp
+++ b/controllers/main_sim/includes/Controller.hpp
@@ -41,7 +41,7 @@ public:
     // Color系
     ColorSensor::ColorValue getColorValue();
     //LineSensor系
-    void getLineValue(int* left, int* center, int* right);
+    LineSensor::LineValue getLineValue();
 };
 
 #endif

--- a/controllers/main_sim/includes/Controller.hpp
+++ b/controllers/main_sim/includes/Controller.hpp
@@ -37,7 +37,7 @@ public:
     // Position系
     Position *position;
     void positionReset(void);
-    void getPosition(float* distance, float* angle);
+    Position::PositionValue getPosition();
     // Color系
     ColorSensor::ColorValue getColorValue();
     //LineSensor系

--- a/controllers/main_sim/includes/Event.hpp
+++ b/controllers/main_sim/includes/Event.hpp
@@ -6,6 +6,7 @@
 #include "includes/CommonDefine.hpp"
 #include "drivers/includes/ColorSensor.hpp"
 #include "drivers/includes/LineSensor.hpp"
+#include "drivers/includes/Position.hpp"
 #include <string>
 
 class Controller;
@@ -39,8 +40,7 @@ private:
     int oldKey;
     float rangeDistanceOld;
     unsigned long event;
-    float distanceOld;
-    float angleOld;
+    Position::PositionValue positionOld;
     ColorSensor::ColorValue colorOld;
     LineSensor::LineValue lineValueOld;
 };

--- a/controllers/main_sim/includes/Event.hpp
+++ b/controllers/main_sim/includes/Event.hpp
@@ -5,6 +5,7 @@
 #include <webots/Keyboard.hpp> //キー受け付け; シミュレータ
 #include "includes/CommonDefine.hpp"
 #include "drivers/includes/ColorSensor.hpp"
+#include "drivers/includes/LineSensor.hpp"
 #include <string>
 
 class Controller;
@@ -41,9 +42,7 @@ private:
     float distanceOld;
     float angleOld;
     ColorSensor::ColorValue colorOld;
-    int lineLeftOld;
-    int lineCenterOld;
-    int lineRightOld;
+    LineSensor::LineValue lineValueOld;
 };
 
 #endif

--- a/controllers/main_sim/includes/LEDTank.hpp
+++ b/controllers/main_sim/includes/LEDTank.hpp
@@ -2,6 +2,7 @@
 #define __LEDTank__
 
 #include "includes/Controller.hpp"
+#include "drivers/includes/Position.hpp"
 
 #define _STATE_INITIAL 0x00000000
 #define STATE_FORWARD ((unsigned long)1)
@@ -24,8 +25,7 @@ public:
     Controller *controller;
     unsigned long _beforeState;
     unsigned long state;
-    float distance;
-    float angle;
+    Position::PositionValue position;
     float rangeDistance;
 };
 #endif


### PR DESCRIPTION
#26 の対応

* `changeDriveMode`に与える引数を，`pwmDuty/voltageLevel`から`motorPower`に変更・統一
* センサ値取得メソッドのうち，ポインタ渡しだったものを引数なし・構造体返しに変更

## ラインセンサ
### `Controller::getLineValue`
引数 なし
返値: `LineSensor::LineValue{int left, center, right}`
振舞: ラインセンサの白黒判定（0or1）を格納する`LineValue`型変数を返す

```C++
LineSensor::LineValue lineValue;
lineValue = Controller::getLineValue();
```

## 自己位置
### `Controller::getPosition`
引数: なし
返値: `Position::PositionValue{float distance, angle}`
振舞: 現在の進んだ距離・角度を格納する`PositionValue`型変数を返す

```C++
Position::PositionValue positionValue;
positionValue = Controller::getPosition();
```