### PR TITLE
ログ出力をAPI化

### DIFF
--- a/controllers/main_sim/Event.cpp
+++ b/controllers/main_sim/Event.cpp
@@ -118,10 +118,6 @@ int Event::updateEvent() {
     this->rangeDistanceOld = rangeDistance;
     this->colorOld = color;
     this->lineValueOld = lineValue;
-    printf("distance=%f, angle=%f \n", position.distance, position.angle);
-    printf("range=%f \n", rangeDistance);
-    printf("color: R=%d, G=%d, B=%d \n", color.red, color.green, color.blue);
-    printf("line: l=%d, c=%d, r=%d \n", lineValue.left, lineValue.center, lineValue.right);
     return 0;
 }
 

--- a/templates/cpp.template
+++ b/templates/cpp.template
@@ -68,3 +68,10 @@ void ${u.name}::doTransition(unsigned long event){
     break;
   }
 }
+
+void ${u.name}::printValues(){
+    printf("distance=%f, angle=%f \\n", positionValue.distance, positionValue.angle);
+    printf("range=%f \\n", rangeDistance);
+    printf("color: R=%d, G=%d, B=%d \\n", colorValue.red, colorValue.green, colorValue.blue);
+    printf("line: l=%d, c=%d, r=%d \\n", lineValue.left, lineValue.center, lineValue.right);
+}

--- a/templates/hpp.template
+++ b/templates/hpp.template
@@ -19,6 +19,7 @@ class ${u.name}{
   void execState();
   void doTransition(unsigned long event);
   unsigned long _state;
+  void printValues();
 
  private:
    Controller *controller;


### PR DESCRIPTION
常に出力されていたセンサ値のログ出力を，API化させて必要な時だけ見れるようにしました．
`printValues()`で出力できます．（`controllers->printValues()`ではないです）
なお，以前のログ出力と少し使用を変更しています．

* 出力する値は，センサからとってきた値ではなくLEDTankが保持している値とした．つまり，`getPositioonValue`()などで更新しないと変化しない．
* もとは`Event.cpp`内で定義されていたが，`LEDTank.cpp`内に入るようにした．すなわち，メソッドはテンプレートに変更を加えた．
* `printValues()`は`PositionValue`,`ColorValue`,`LineValue`の存在を前提としており，それらが定義されていないとビルドが通らない